### PR TITLE
Add validator for Cabinet Office emails

### DIFF
--- a/pulse_survey/survey/forms.py
+++ b/pulse_survey/survey/forms.py
@@ -2,11 +2,19 @@
 from django import forms
 from django.core.exceptions import ValidationError
 
+CABINET_OFFICE_DOMAINS = ("digital.cabinet-office.gov.uk", "cabinetoffice.gov.uk", "no10.gov.uk")
 
-def is_cabinet_office_email(email_address):
-    # TODO - update to raise a ValidationError for non-Cabinet Office emails
+
+def is_cabinet_office_email(email_address: str) -> bool:
+    """
+    This function checks whether the email address given ends in a Cabinet Office domain. If there are changes to the
+    business units in the Cabinet Office, the constant CABINET_OFFICE_DOMAINS should be updated. This does not confirm
+    whether the address is actually valid; whether it's connected to a person; or anything else: only that it is a
+    possible Cabinet Office email address
+    """
+    if not email_address.lower().split("@")[-1] in CABINET_OFFICE_DOMAINS:
+        raise ValidationError("Please enter a Cabinet Office email address")
     return True
-    
 
 
 class FeedbackForm(forms.Form):

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -12,17 +12,34 @@ class FeedbackFormTest(TestCase):
         email_errors = form.errors["email"]
         self.assertTrue("Enter a valid email address" in str(email_errors))
 
-    def test_correct_email(self):
+    def test_good_email_with_bad_domain(self):
         form = forms.FeedbackForm({"email": "test@example.com", "content": "some feedback"})
         form.is_valid()
-        no_email_errors = "email" not in form.errors
-        self.assertTrue(no_email_errors)
+        email_errors = form.errors["email"]
+        self.assertTrue("Please enter a Cabinet Office email address" in str(email_errors))
+
+    def test_good_email(self):
+        cases = (
+            {"case": "No 10", "address": "PM@No10.gov.uk"},
+            {"case": "GDS", "address": "CEO@digital.cabinet-office.gov.uk"},
+        )
+        for test_case in cases:
+            with self.subTest(test_case['case']):
+                form = forms.FeedbackForm({"email": test_case['address'], "content": "some feedback"})
+                form.is_valid()
+                no_email_errors = "email" not in form.errors
+                self.assertTrue(no_email_errors)
 
 
 class CabinetOfficeValidationTest(SimpleTestCase):
     def test_is_cabinet_office_email(self):
-        valid_email = "valid@example.com"
-        result = forms.is_cabinet_office_email(valid_email)
-        self.assertTrue(result)
+        cases = (
+            {"case": "No 10", "address": "PM@No10.gov.uk"},
+            {"case": "GDS", "address": "CEO@digital.cabinet-office.gov.uk"},
+        )
+        for test_case in cases:
+            with self.subTest(test_case['case']):
+                result = forms.is_cabinet_office_email(test_case['address'])
+                self.assertTrue(result)
 
 


### PR DESCRIPTION
This is a non-exhaustive and extensible approach to verifying Cabinet Office email. There is more than one domain within the CO, and this code attempts to be flexible enough to deal with all of them.

There is no validation on whether the user accidentally added a space or comma or similar - they will need to try it again.