### PR TITLE
Test emails are saved in lowercase

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,3 +1,5 @@
+import string
+
 from django.test import TestCase
 
 from pulse_survey.survey import models
@@ -8,3 +10,9 @@ class FeedbackModelTest(TestCase):
         feedback = models.Feedback(email="Test@Example.Com", content="Some feedback")
         feedback.save()
         self.assertEqual(feedback.content, "Some feedback")
+
+    def test_email_saved_in_lower_case(self):
+        email = "MixTuRe.of.CAPiTals@cabinetoffice.gov.uk"
+        feedback = models.Feedback(email=email, content="Not important")
+        feedback.save()
+        self.assertTrue(set(feedback.email).isdisjoint(set(string.ascii_uppercase)), "No uppercase in email")


### PR DESCRIPTION
This gets around the problem of describing what can be in an email address (almost anything!) by instead asserting what can't be: capital letters